### PR TITLE
feat: store proper file names

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -43,6 +43,7 @@ func createTables(db *sqlx.DB) error {
 			"user_id" INTEGER NOT NULL,
 			"ext" TEXT NOT NULL,
 			"blob" BLOB NOT NULL,
+			"original_filename" TEXT NOT NULL DEFAULT '',
 			"delete_token" TEXT NOT NULL
 		);
     `); err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -23,7 +23,7 @@ func NewServer(db *sqlx.DB, conf *config.Config) *Server {
 	mux := http.NewServeMux()
 
 	mux.Handle("/upload", log.WrapHandler(logger, &uploadHandler{db: db, conf: conf}))
-	mux.Handle("/f/", log.WrapHandler(logger, &viewHandler{db: db}))
+	mux.Handle("/f/", log.WrapHandler(logger, &viewHandler{db: db, conf: conf}))
 	mux.Handle("/del", log.WrapHandler(logger, &deleteHandler{db: db}))
 	mux.Handle("/export", log.WrapHandler(logger, &exportHandler{db: db, conf: conf}))
 	mux.Handle("/test-auth", log.WrapHandler(logger, &authHandler{db: db, conf: conf}))

--- a/static/assets/index.js
+++ b/static/assets/index.js
@@ -62,6 +62,34 @@ async function getFiles() {
   return json.data;
 }
 
+async function doRenameFile(url, currentName) {
+  const token = getAccessToken();
+  if (!token) return false;
+
+  let newName = prompt("What should this file be called?", currentName);
+  if (!newName || newName.trim() == "") {
+    return;
+  }
+
+  const res = await fetch(url, {
+    method: "PUT",
+    headers: {
+      "X-SX-API-KEY": token,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      name: newName,
+    }),
+  });
+  if (res.status !== 200) {
+    alert("Failed to rename. Check console.");
+    console.log(res);
+    return;
+  }
+
+  window.location = window.location;
+}
+
 function buildFileEntriesHTML(files) {
   let html = "";
 
@@ -79,8 +107,9 @@ function buildFileEntriesHTML(files) {
             <img src="${url}" alt="Preview Photo" />
           </a>
           <div class="content">
-            <p class="title">${file.id}${file.ext}</p>
+            <p class="title">${file.original_filename} (${file.id})</p>
             <div class="span">
+              <a class="rename" onClick="doRenameFile('${url}', '${file.original_filename}')">Rename</a>
               <a href="${deleteUrl}">Delete</a>
             </div>
           </div>
@@ -94,8 +123,9 @@ function buildFileEntriesHTML(files) {
             <p class="wrn-text">No preview available for this filetype. Click to open the file in a new tab.</p>
           </a>
           <div class="content">
-            <p class="title">${file.id}${file.ext}</p>
+            <p class="title">${file.original_filename} (${file.id})</p>
             <div class="span">
+              <a class="rename" onClick="doRenameFile('${url}', '${file.original_filename}')">Rename</a>
               <a href="${deleteUrl}">Delete</a>
             </div>
           </div>

--- a/static/assets/style.css
+++ b/static/assets/style.css
@@ -201,6 +201,11 @@ tr:nth-child(odd) {
   text-decoration: none;
 }
 
+.file-grid .file a:hover {
+  text-decoration: underline;
+  text-decoration-thickness: 3;
+}
+
 .file-grid .file .img-container .wrn-text {
   text-align: center;
   color: white;
@@ -218,4 +223,9 @@ tr:nth-child(odd) {
 .file-grid .file .content .title {
   font-weight: 600;
   font-size: 1.25rem;
+}
+
+.rename {
+  color: green;
+  cursor: pointer;
 }


### PR DESCRIPTION
## Pull Request Type
Feature

## Details
- Adds `"original_filename" TEXT NOT NULL DEFAULT ''` to SQL schema
- Stores the original filename provided by the user when they upload
- Allow people to rename the files through the dashboard

## Migration Details
- SSH Into the host, and apply the migrations to the SQLite file manually.

  ```sql
  -- Run this to add the new column
  ALTER TABLE "files" ADD COLUMN "original_filename" TEXT NOT NULL DEFAULT '';
  ```